### PR TITLE
Fix nucgen flags in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ gen_data:
     @mkdir -p data
     for size in {{RECORD_SIZES}}; do \
         echo "Generating records of size ${size}"; \
-        nucgen -fq -n {{NUM_RECORDS}} -l $size -o data/records_${size}.fastq; \
+        nucgen -fq -n {{NUM_RECORDS}} -l $size data/records_${size}.fastq; \
     done
 
 run_benchmarks:


### PR DESCRIPTION
Hi there!
I'm excited to give `paraseq` a try and wanted to have a look at the benchmark!
This PR simply removes the `-o` flag when calling nucgen with `just gen_data` (otherwise it crashes on my machine).